### PR TITLE
Reversed table should have a new line before end of file.

### DIFF
--- a/src/main/groovy/org/disl/db/reverseEngineering/ReverseTablePattern.groovy
+++ b/src/main/groovy/org/disl/db/reverseEngineering/ReverseTablePattern.groovy
@@ -66,7 +66,8 @@ ${description(pattern.table.description)}$foreignKeyDefinition
 class $pattern.table.name extends ${pattern.parentClassName} {
 
 $columnDefinitions
-}"""
+}
+"""
         }
 
         String getColumnDefinitions() {

--- a/src/test/groovy/org/disl/db/reverseEngineering/TestReverseTablePattern.groovy
+++ b/src/test/groovy/org/disl/db/reverseEngineering/TestReverseTablePattern.groovy
@@ -56,7 +56,8 @@ class TestDimensionTable extends AbstractL2Table {
 		@DataType(\"""VARCHAR(200)\""")
 		@NotNull
 		Column NAME
-}"""
+}
+"""
         pattern.execute()
         assertEquals(expectedContent, new File("build/test/l2/TestDimensionTable.groovy").getText())
     }


### PR DESCRIPTION
File should end with a new line when reversing a table.
See https://unix.stackexchange.com/questions/18743/whats-the-point-in-adding-a-new-line-to-the-end-of-a-file for details.