### PR TITLE
[MAT-537] Make createAll deterministic by sorting by name

### DIFF
--- a/src/main/groovy/org/disl/meta/MetaFactory.groovy
+++ b/src/main/groovy/org/disl/meta/MetaFactory.groovy
@@ -58,7 +58,7 @@ class MetaFactory {
         if (typesToCreate.size() == 0) {
             throw new RuntimeException('No classes found!')
         }
-        typesToCreate.collect { create(it) }
+        typesToCreate.sort{it.name}.collect { create(it) }
     }
 
     /**


### PR DESCRIPTION
`MetaFactory.createAll` seems to be ordering returned results differently on Windows vs macOS, causing liquibase changelog generation in collibra/outbound-database to be non-deterministic. This pull introduces a sort on the `.name` property in order to resolve this issue.